### PR TITLE
Simulación de carga de pantalla de login

### DIFF
--- a/lib/presentation/screens/login.dart
+++ b/lib/presentation/screens/login.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class Login extends StatelessWidget {
+  const Login({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login'),
+      ),
+      body: const Center(
+        child: Text('Esta es la pantalla de login'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/logos_imagenes.dart
+++ b/lib/presentation/screens/logos_imagenes.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:wapig/presentation/provider/discover_provider.dart';
+
+class LogoImagenes
+ extends StatelessWidget {
+  const LogoImagenes
+  ({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final discoverProvider = Provider.of<DiscoverProvider>(context);
+
+    return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Center(
+            child: Image.asset(
+              'assets/images/logoWapig.png',
+              width: 300,
+              height: 300,
+            ),
+          ),
+          const Center(
+            child: Text(
+              'WAPIG',
+              style: TextStyle(
+                  fontFamily: 'Sansita',
+                  fontSize: 52,
+                  fontWeight: FontWeight.bold),
+            ),
+          ),
+          const SizedBox(height: 20,),
+
+          if (discoverProvider.initialLoading)
+            const Center(
+              child: CircularProgressIndicator(),
+            ),
+          Padding(
+            padding: const EdgeInsets.only(top: 50),
+            child: Center(
+              child: Image.asset(
+                'assets/images/logo_b_n.png',
+                width: 120,
+                height: 60,
+              ),
+            ),
+          ),
+        ],
+      );
+  }
+}

--- a/lib/presentation/screens/screen_welcome.dart
+++ b/lib/presentation/screens/screen_welcome.dart
@@ -1,52 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import 'package:wapig/presentation/provider/discover_provider.dart';
+import 'package:wapig/presentation/screens/login.dart';
+import 'package:wapig/presentation/screens/logos_imagenes.dart';
 
 class ScreenWelcome extends StatelessWidget {
   const ScreenWelcome({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final discoverProvider = Provider.of<DiscoverProvider>(context);
-    return Scaffold(
-      backgroundColor: const Color.fromARGB(255, 169, 242, 248),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Center(
-            child: Image.asset(
-              'assets/images/logoWapig.png',
-              width: 300,
-              height: 300,
-            ),
-          ),
-          const Center(
-            child: Text(
-              'WAPIG',
-              style: TextStyle(
-                  fontFamily: 'Sansita',
-                  fontSize: 52,
-                  fontWeight: FontWeight.bold),
-            ),
-          ),
-          const SizedBox(height: 20,),
 
-          if (discoverProvider.initialLoading)
-            const Center(
-              child: CircularProgressIndicator(),
-            ),
-          Padding(
-            padding: const EdgeInsets.only(top: 50),
-            child: Center(
-              child: Image.asset(
-                'assets/images/logo_b_n.png',
-                width: 120,
-                height: 60,
-              ),
-            ),
-          ),
-        ],
-      ),
+    //Se simula el llamado a la pantalla de login
+    Future.delayed(const Duration(seconds: 3), () {
+      // Navegar a la próxima pantalla (Home)
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const Login()),
+      );
+    });
+    
+    return const Scaffold(
+      backgroundColor: Color.fromARGB(255, 169, 242, 248),
+      body: LogoImagenes()
     );
   }
 }


### PR DESCRIPTION
Rama origen: master

Rama actual de trabajo: req-20240109-01

Archivos modificados:
lib/presentation/screens/login.dart
lib/presentation/screens/logos_imagenes.dart
lib/presentation/screens/screen_welcome.dart

Resumen del commit: Se crea la transición entre la pantalla de welcome y la pantalla de login. Se hace mediante una simulación de delayed. Se configuró el Provider.